### PR TITLE
Handle different venv pathing depending on OS

### DIFF
--- a/set-up-python-venv.sh
+++ b/set-up-python-venv.sh
@@ -16,7 +16,11 @@ else
 
     virtualenv --python=python3 venv
 
-    source venv/bin/activate
+    if [ "$(uname)" = "Darwin" ] || [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+        source venv/bin/activate
+    else
+        source venv/Scripts/activate
+    fi
 
     if [ -f requirements.txt ]; then
       pip install -r requirements.txt


### PR DESCRIPTION
For Windows, the venv pathing is slightly different. Instead of venv/bin/, it is venv/Scripts/. This is mostly to handle that