### PR TITLE
Create basic editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+# Set default charset and indentation style
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Max line length for python files
+[*.py]
+max_line_length = 80
+
+# Tab indentation for Makefile (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I created a basic editorconfig based on [Editorconfig webpage](https://editorconfig.org/) example for our project. Will need to adjust when more types of files are introduced. VS Code users might need to download extension plugins since VSCode does not have native support for Editorconfig.