### PR TITLE
Clean up logger declaration

### DIFF
--- a/src/main/py/sample_module/udp_server.py
+++ b/src/main/py/sample_module/udp_server.py
@@ -18,6 +18,8 @@ class UdpServer:
     next message is recieved.
     """
 
+    logger = logging.getLogger("UdpServer")
+
     def __init__(self, server_ip: str, listen_port: int) -> None:
         """Construct a `UdpServer`.
 
@@ -25,7 +27,6 @@ class UdpServer:
         server_ip   -- the ip to bind to
         listen_port -- the port to listen on
         """
-        UdpServer.logger = logging.getLogger("UdpServer")
         self.ip = server_ip
         self.port = listen_port
         self.cached_message = ""


### PR DESCRIPTION
The logger declaration should be up at the class definition level to make it more clear it's a Class Variable. Also, having defined in `__init__` with Class Variable syntax _may_ still result in a reassignment for every instance creation. Which would, obviously, be inefficient and unnecessary.