### PR TITLE
Make line length consistent across code formatters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ charset = utf-8
 
 # Max line length for python files
 [*.py]
-max_line_length = 80
+max_line_length = 88
 
 # Tab indentation for Makefile (no size specified)
 [Makefile]


### PR DESCRIPTION
We've been using Ruff for formatting, which defaults to 88 characters for its max line length. So we don't end up with a lot of whitespace changes for existing files and contention between Ruff and Editor Config, this commit set the line length for Editor Config to match Ruff's default.

In addition, the PEP 8 standard of 80 characters is too restrictive and does not make much sense given modern displays. It probably reflects what made sense in 2001 when it was adopted.