### PR TITLE
Add clean option for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,9 @@ run:
 test: ruff pylint
 	export PYTHONPATH=src/main/py; \
 	python3 -m unittest discover --pattern "*_test.py" --start-directory src/test/py --top-level-directory .
+
+clean:
+	@echo "I'm cleaning OwO"
+	rm -rf venv
+	find . -name "*.pyc" -delete
+	find . -type d -name "__pycache__" -delete

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,6 @@ test: ruff pylint
 	export PYTHONPATH=src/main/py; \
 	python3 -m unittest discover --pattern "*_test.py" --start-directory src/test/py --top-level-directory .
 
-clean-env:
-	@echo "I'm cleaning the environment OwO"
-	command -v deactivate && deactivate
-	rm -rf venv
-
 clean-src:
 	@echo "Cleaning source"
 	find src/ -type d -name "__pycache__" -print0 | xargs -0 rm -rf

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ test: ruff pylint
 	export PYTHONPATH=src/main/py; \
 	python3 -m unittest discover --pattern "*_test.py" --start-directory src/test/py --top-level-directory .
 
-clean:
-	@echo "I'm cleaning OwO"
+clean-env:
+	@echo "I'm cleaning the environment OwO"
+	command -v deactivate && deactivate
 	rm -rf venv
-	find . -name "*.pyc" -delete
-	find . -type d -name "__pycache__" -delete
+
+clean-src:
+	@echo "Cleaning source"
+	find src/ -type d -name "__pycache__" -print0 | xargs -0 rm -rf


### PR DESCRIPTION
Recently had a problem when forgotting to clean venv on my Windows machine leading to Permission Error. Looks like it's treating the venv created on my previous session as not belonging to me. Weird, but cleaning it and remaking the venv solves the issue, so I'm just creating an option for cleaning for convenience if anyone needs it.