### PR TITLE
Set up code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
-.PHONY: pylint ruff run test
+.PHONY: clean clean-build clean-src pylint ruff run test
 
 .DEFAULT_GOAL := test
+
+clean: clean-build clean-src
+
+clean-build:
+	@echo ">>> Cleaning build"
+	rm -rf build
+
+clean-src:
+	@echo ">>> Cleaning source"
+	find src/ -type d -name "__pycache__" -print0 | xargs -0 rm -rf
 
 pylint:
 	pylint --recursive=y src/*/py
@@ -15,8 +25,9 @@ run:
 
 test: ruff pylint
 	export PYTHONPATH=src/main/py; \
-	python3 -m unittest discover --pattern "*_test.py" --start-directory src/test/py --top-level-directory .
+	    coverage run -m unittest discover --pattern "*_test.py" \
+		  --start-directory src/test/py \
+		  --top-level-directory .
+	coverage report
+	coverage html
 
-clean-src:
-	@echo "Cleaning source"
-	find src/ -type d -name "__pycache__" -print0 | xargs -0 rm -rf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+[tool.coverage.report]
+exclude_also = [
+  "if 0:",
+  "^if[ \t]+__name__[ \t]+==[ \t]+['\"]__main__['\"]",
+]
+ignore_errors = true
+show_missing = true
+skip_empty = true
+
+[tool.coverage.run]
+omit = [ "src/test/*", ]
+branch = true
+
+[tool.coverage.html]
+directory = "build/htmlcov"
+skip_empty = true
+
 [tool.pylint]
 # I prefer to allow an empty line at the end of a source file.
 disable = ["trailing-newlines"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astroid==3.0.2
+coverage==7.4.0
 dill==0.3.7
 isort==5.13.2
 mccabe==0.7.0


### PR DESCRIPTION
This commit sets up the build to run the `codecoverage` tool when running the tests and to output a coverage report. It also reworks the `Makefile` to be more refined and use make best practices.