### PR TITLE
Enhance the start-up to generate public/private key pairs and store them in the peer list file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 
 # Spin up script
 devops/deploy/port_list.txt
+devops/deploy/peer_list.txt
+devops/deploy/keys/

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,5 @@ ENV/
 .ropeproject
 
 # Spin up script
-devops/deploy/port_list.txt
 devops/deploy/peer_list.txt
 devops/deploy/keys/

--- a/devops/deploy/spin-down-script.sh
+++ b/devops/deploy/spin-down-script.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-PORT_LIST="peer_list.txt"
+PEER_LIST="peer_list.txt"
 # Now fully implemented spinning down through the port_list.txt
 IP=127.0.0.1
 declare -a PORTS=()

--- a/devops/deploy/spin-down-script.sh
+++ b/devops/deploy/spin-down-script.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-PORT_LIST="port_list.txt"
+PORT_LIST="peer_list.txt"
 # Now fully implemented spinning down through the port_list.txt
 IP=127.0.0.1
 declare -a PORTS=()
 while IFS= read -r line
 do
-	PORTS+=("$line")
+	PORTS+=("$(echo $line | awk -F, '{print $2}')")
 done < "$PORT_LIST"
 
 # Iterate through the list, killing each controlling process while looping

--- a/devops/deploy/spin-down-script.sh
+++ b/devops/deploy/spin-down-script.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+PORT_LIST="port_list.txt"
 # Now fully implemented spinning down through the port_list.txt
 IP=127.0.0.1
 declare -a PORTS=()
 while IFS= read -r line
 do
 	PORTS+=("$line")
-done < "port_list.txt"
+done < "$PORT_LIST"
 
 # Iterate through the list, killing each controlling process while looping
 for port in ${PORTS[*]}
@@ -16,4 +17,4 @@ do
 	kill -15 $(netstat -anp | grep $temp | awk '{print $6}' | awk -F/ '{print $1}')
 done
 
-echo -n > "port_list.txt"
+echo -n > "$PORT_LIST"

--- a/devops/deploy/spin-down-script.sh
+++ b/devops/deploy/spin-down-script.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 PEER_LIST="peer_list.txt"
-# Now fully implemented spinning down through the port_list.txt
+# Now fully implemented spinning down through the peer_list.txt
 IP=127.0.0.1
 declare -a PORTS=()
 while IFS= read -r line
 do
 	PORTS+=("$(echo $line | awk -F, '{print $2}')")
-done < "$PORT_LIST"
+done < "$PEER_LIST"
 
 # Iterate through the list, killing each controlling process while looping
 for port in ${PORTS[*]}
@@ -17,4 +17,4 @@ do
 	kill -15 $(netstat -anp | grep $temp | awk '{print $6}' | awk -F/ '{print $1}')
 done
 
-echo -n > "$PORT_LIST"
+echo -n > "$PEER_LIST"

--- a/devops/deploy/spin-up-script.sh
+++ b/devops/deploy/spin-up-script.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Just a basic script to spin up listening servers on different ports in dynamic port range
 # Setting up variables
 PSTART=${1:-50000}
 PEND=${2:-50050}
-PEER_FILE="peer_list.txt"
+PEER_FILE="peer_list1.txt"
 IP=127.0.0.1
 COUNT=0
 ((NUM_PORTS=${PEND}-${PSTART}))
@@ -15,6 +15,15 @@ then
 	echo "Directory keys exists."
 else
 	mkdir keys/
+fi
+
+# Making Peer file if it does not exist
+if [ -f $PEER_FILE ]
+then
+	echo "Peer List File exists"
+else
+	touch $PEER_FILE
+	chmod 600 $PEER_FILE
 fi
 
 echo "Total number of ports: $NUM_PORTS"

--- a/devops/deploy/spin-up-script.sh
+++ b/devops/deploy/spin-up-script.sh
@@ -1,25 +1,44 @@
 #!/bin/bash
 
+# Just a basic script to spin up listening servers on different ports in dynamic port range
+# Setting up variables
 PSTART=${1:-50000}
 PEND=${2:-50050}
-# Just a basic script to spin up listening servers on different ports in dynamic port range
+PEER_FILE="peer_list.txt"
 IP=127.0.0.1
 COUNT=0
 ((NUM_PORTS=${PEND}-${PSTART}))
+
+# Making keys directory to hold public/private keys if not exist
+if [ -d keys/ ]
+then
+	echo "Directory keys exists."
+else
+	mkdir keys/
+fi
 
 echo "Total number of ports: $NUM_PORTS"
 export PYTHONPATH=../../src/main/py
 
 port=$PSTART
 
-while [ ${COUNT} -lt ${NUM_PORTS} ]
+while [ ${COUNT} -le ${NUM_PORTS} ]
 do
   #Check for Open ports, if open then OK, else continue
   if ! netstat -apn | grep -q "$IP:$port" 
   then
+    # Generating keys
+    ssh-keygen -t ed25519 -f "keys/node${COUNT}" -N ""
+
+    private_key=$(cat keys/node${COUNT} | awk -F '-----' '{print $1}' | tr -d '\n')
+    public_key=$(cat keys/node${COUNT}.pub | awk -F '-----' '{print $1}' | tr -d '\n')
+    # Handling putting the port information and the keys into the peer list
     echo "Starting on port $port"
-    python3 -m sample_module.udp_server ${port} &
-    echo "$port" >> port_list.txt
+    echo $public_key
+
+    # Calling server
+    #python3 -m sample_module.udp_server ${port} &
+    echo "${COUNT} ,${port} ,${private_key} ,${public_key}" >> $PEER_FILE
     ((port++))
     ((COUNT++))
   else

--- a/devops/deploy/spin-up-script.sh
+++ b/devops/deploy/spin-up-script.sh
@@ -4,8 +4,8 @@
 # Setting up variables
 PSTART=${1:-50000}
 PEND=${2:-50050}
-PEER_FILE="peer_list1.txt"
-IP=127.0.0.1
+PEER_FILE="peer_list.txt"
+IP="127.0.0.1"
 COUNT=0
 ((NUM_PORTS=${PEND}-${PSTART}))
 

--- a/devops/deploy/spin-up-script.sh
+++ b/devops/deploy/spin-up-script.sh
@@ -37,7 +37,7 @@ do
     
     # Handling putting the port information and the keys into the peer list
     echo "Starting on port $port"
-    echo "${COUNT} ,${port} ,${private_key} ,${public_key}" >> $PEER_FILE
+    echo "${COUNT},${port},${private_key},${public_key}" >> $PEER_FILE
 
     # Calling server
     python3 -m sample_module.udp_server ${port} &

--- a/devops/deploy/spin-up-script.sh
+++ b/devops/deploy/spin-up-script.sh
@@ -22,6 +22,7 @@ export PYTHONPATH=../../src/main/py
 
 port=$PSTART
 
+# Loop for spinning up
 while [ ${COUNT} -le ${NUM_PORTS} ]
 do
   #Check for Open ports, if open then OK, else continue
@@ -30,15 +31,16 @@ do
     # Generating keys
     ssh-keygen -t ed25519 -f "keys/node${COUNT}" -N ""
 
+    # Cutting the keys from the key files
     private_key=$(cat keys/node${COUNT} | awk -F '-----' '{print $1}' | tr -d '\n')
     public_key=$(cat keys/node${COUNT}.pub | awk -F '-----' '{print $1}' | tr -d '\n')
+    
     # Handling putting the port information and the keys into the peer list
     echo "Starting on port $port"
-    echo $public_key
+    echo "${COUNT} ,${port} ,${private_key} ,${public_key}" >> $PEER_FILE
 
     # Calling server
-    #python3 -m sample_module.udp_server ${port} &
-    echo "${COUNT} ,${port} ,${private_key} ,${public_key}" >> $PEER_FILE
+    python3 -m sample_module.udp_server ${port} &
     ((port++))
     ((COUNT++))
   else


### PR DESCRIPTION
The spin-up-script are supposed to be only called once per spin-down-script with this implementation.