### PR TITLE
Update CI steps

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up python environment
-      run: source set-up-python-venv.sh -d -f
+      run: source set-up-python-venv.sh -d
 
     - name: Run linters and tests
       run: source venv/bin/activate && make test


### PR DESCRIPTION
* Update the version of `actions/checkout` to v4 to address warning in the build console.
* Remove force flag from venv setup, since the logic should now correctly detect that it's being sourced in the CI environment.