### PR TITLE
Fail build on invalid source format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,18 @@ clean-src:
 pylint:
 	pylint --recursive=y src/*/py
 
-ruff:
-	ruff format
-	ruff .
+ruff-check:
+	ruff format --check .
+	ruff check .
+
+ruff-format:
+	ruff format .
 
 run:
 	export PYTHONPATH=src/main/py; \
 		python3 -m peer.peer 50000 "src/test/py/resources/peer_test" "0.0.0.0:50000"
 
-test: ruff pylint
+test: ruff-check pylint
 	export PYTHONPATH=src/main/py; \
 	    coverage run -m unittest discover --pattern "*_test.py" \
 		  --start-directory src/test/py \

--- a/devops/deploy/supervisor.py
+++ b/devops/deploy/supervisor.py
@@ -17,7 +17,17 @@ logging.basicConfig(
 # Placeholder for function to recover nodes recover_node(host, port)
 def recover_node(node_number, host, port):
     key_file = "node" + str(node_number)
-    subprocess.run(["python3", "-m", "peer.contributing_peer", port, key_file, host + ":50000", "&"])
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "peer.contributing_peer",
+            port,
+            key_file,
+            host + ":50000",
+            "&",
+        ]
+    )
 
 
 # Function to check if a node is alive

--- a/src/main/py/peer/peer.py
+++ b/src/main/py/peer/peer.py
@@ -85,7 +85,9 @@ class Peer:
             else:
                 self.logger.error("Commission failed to complete")
             self.inventory.add_owned_artwork(commission)
-            self.inventory.commission_canvases[commission.key].save("pics/canvas13.png", "PNG")
+            self.inventory.commission_canvases[commission.key].save(
+                "pics/canvas13.png", "PNG"
+            )
             self.inventory.remove_commission(commission)
         except TypeError:
             self.logger.info(commission)


### PR DESCRIPTION
Source that doesn't comply with our code style is consistently getting checked in. This commit changes the build verification to fail the build in that case.